### PR TITLE
Update installer.php

### DIFF
--- a/upload/admin/controller/extension/installer.php
+++ b/upload/admin/controller/extension/installer.php
@@ -279,7 +279,7 @@ class ControllerExtensionInstaller extends Controller {
 			while (count($path) != 0) {
 				$next = array_shift($path);
 
-				foreach (glob($next) as $file) {
+				foreach ((array)glob($next) as $file) {
 					if (is_dir($file)) {
 						$path[] = $file . '/*';
 					}


### PR DESCRIPTION
Changed on line 282:
foreach (glob($next) as $file) 
now changed to: 
foreach ((array)glob($next) as $file) 

Adding the (array) allows for uploads of the ocmod.zip files with an empty upload folder, as it checks id glob($next) is an array. in the original code there could be an error if the upload folder was empty and without the folder, the upload with a zip file won't work.

You still want to use the zip in case you have both and xml and sql file to install your ocmod.
